### PR TITLE
fix: correct GitRepository name to flux-system

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -16,7 +16,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: k3s-homelab
+    name: flux-system
   wait: true
   interval: 30m
   timeout: 15m

--- a/kubernetes/apps/storage/ceph-csi-rbd/ks.yaml
+++ b/kubernetes/apps/storage/ceph-csi-rbd/ks.yaml
@@ -16,7 +16,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: k3s-homelab
+    name: flux-system
   wait: true
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
Fixes sourceRef.name in Kustomizations - should reference the existing `flux-system` GitRepository, not `k3s-homelab`.