### PR TITLE
fix(storage): correct cilium dependency namespace to kube-system

### DIFF
--- a/kubernetes/apps/storage/ceph-csi-rbd/ks.yaml
+++ b/kubernetes/apps/storage/ceph-csi-rbd/ks.yaml
@@ -11,7 +11,7 @@ spec:
       app.kubernetes.io/name: ceph-csi-rbd
   dependsOn:
     - name: cilium
-      namespace: flux-system
+      namespace: kube-system
   path: ./kubernetes/apps/storage/ceph-csi-rbd/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Cilium Kustomization is deployed in `kube-system` namespace, not `flux-system`.