### PR TITLE
fix(storage): correct HelmRepository namespace reference

### DIFF
--- a/kubernetes/apps/storage/ceph-csi-rbd/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ceph-csi-rbd/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: ceph-csi
-        namespace: flux-system
+        namespace: storage
   values:
     csiConfig:
       - clusterID: "eb53e78d-4b17-4e8c-8186-cd82025a8917"

--- a/kubernetes/apps/storage/ceph-csi-rbd/app/helmrepository.yaml
+++ b/kubernetes/apps/storage/ceph-csi-rbd/app/helmrepository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ceph-csi
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://ceph.github.io/csi-charts


### PR DESCRIPTION
HelmRepository is created in storage namespace due to targetNamespace, so HelmRelease sourceRef must reference storage namespace.