### PR TITLE
fix(monitoring): revert kube-prometheus-stack to 72.9.1

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 80.0.0
+      version: 72.9.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community


### PR DESCRIPTION
v80.0.0 upgrade failed with timeout during Helm upgrade. Reverting to stable v72.9.1 which is currently running.