### PR TITLE
feat(monitoring): upgrade kube-prometheus-stack to v80.0.0

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -5,13 +5,19 @@ metadata:
   name: kube-prometheus-stack
 spec:
   interval: 30m
+  timeout: 15m
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 72.9.1
+      version: 80.0.0
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
   values:
     crds:
       enabled: true


### PR DESCRIPTION
Previous upgrade failed due to 5min timeout. This adds:
- 15min timeout for major version upgrade
- CRD replacement during upgrade
- Cleanup on failure
- 3 retries