### PR TITLE
fix(monitoring): use Recreate strategy for Grafana

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -40,6 +40,8 @@ spec:
       enabled: true
       defaultDashboardsEnabled: true
       defaultDashboardsTimezone: America/Los_Angeles
+      deploymentStrategy:
+        type: Recreate
       admin:
         existingSecret: grafana-admin
         userKey: admin-user


### PR DESCRIPTION
Grafana uses RWO PVC which requires Recreate deployment strategy for rolling updates.