### PR TITLE
fix(ci): correct flux-diff checkout paths for flux-local action

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -24,16 +24,16 @@ jobs:
           - helmrelease
           - kustomization
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Checkout PR
+        uses: actions/checkout@v4
         with:
-          path: pull
+          path: pr
 
       - name: Checkout default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
-          path: main
+          path: live
 
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
@@ -43,7 +43,7 @@ jobs:
         id: diff
         with:
           live-branch: main
-          path: pull/kubernetes/flux
+          path: pr/kubernetes/flux
           resource: ${{ matrix.resource }}
 
       - name: Add comment


### PR DESCRIPTION
The allenporter/flux-local/action/diff action expects:
- PR checkout in 'pr/' directory  
- Live branch checkout in 'live/' directory

This was causing all Flux Diff checks to fail on PRs.