### PR TITLE
fix(ci): remove redundant pr/ prefix from flux-diff path

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -43,7 +43,7 @@ jobs:
         id: diff
         with:
           live-branch: main
-          path: pr/kubernetes/flux
+          path: kubernetes/flux
           resource: ${{ matrix.resource }}
 
       - name: Add comment


### PR DESCRIPTION
The allenporter/flux-local/action/diff action automatically prefixes paths with pr/ and live/, so we should only specify the relative path (kubernetes/flux) without the checkout directory.