### PR TITLE
feat(homepage): migrate config from Runtipi with SOPS secrets

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
       create: true
       name: homepage
 
+    envFrom:
+      - secretRef:
+          name: homepage-config
+
     service:
       main:
         ports:
@@ -31,76 +35,242 @@ spec:
 
     ingress:
       main:
-        enabled: false  # Using Gateway API instead
+        enabled: false
 
     config:
       bookmarks:
         - Developer:
             - Github:
                 - abbr: GH
-                  href: https://github.com/sagaragas
-            - Cloudflare:
-                - abbr: CF
-                  href: https://dash.cloudflare.com
-        - Infrastructure:
-            - Proxmox:
-                - abbr: PVE
-                  href: https://172.16.1.2:8006
-            - AdGuard:
-                - abbr: AG
-                  href: http://172.16.1.11
-            - Technitium:
-                - abbr: DNS
-                  href: http://172.16.1.10:5380
+                  href: https://github.com/
+        - Social:
+            - Reddit:
+                - abbr: RE
+                  href: https://reddit.com/
+        - Entertainment:
+            - YouTube:
+                - abbr: YT
+                  href: https://youtube.com/
 
       services:
-        - Kubernetes:
-            - Flux:
-                icon: flux-cd
-                href: https://github.com/sagaragas/k3s-homelab
-                description: GitOps Repository
-            - Grafana:
-                icon: grafana
-                href: https://grafana.ragas.cc
-                description: Monitoring Dashboard
-            - Documentation:
-                icon: bookstack
-                href: https://docs.ragas.cc
-                description: Homelab Docs
+        - Hypervisor:
+            - Server-1:
+                icon: proxmox.svg
+                href: https://172.16.1.2:8006
+                description: pve1
+                widget:
+                  type: proxmox
+                  url: https://172.16.1.2:8006
+                  username: "{{HOMEPAGE_VAR_PROXMOX_USER}}"
+                  password: "{{HOMEPAGE_VAR_PROXMOX_PASS}}"
+                  node: pve1
+            - Server-2:
+                icon: proxmox.svg
+                href: https://172.16.1.3:8006
+                description: pve2
+                widget:
+                  type: proxmox
+                  url: https://172.16.1.3:8006
+                  username: "{{HOMEPAGE_VAR_PROXMOX_USER}}"
+                  password: "{{HOMEPAGE_VAR_PROXMOX_PASS}}"
+                  node: pve2
+            - Server-3:
+                icon: proxmox.svg
+                href: https://172.16.1.4:8006
+                description: pve3
+                widget:
+                  type: proxmox
+                  url: https://172.16.1.4:8006
+                  username: "{{HOMEPAGE_VAR_PROXMOX_USER}}"
+                  password: "{{HOMEPAGE_VAR_PROXMOX_PASS}}"
+                  node: pve3
+            - Server-4:
+                icon: proxmox.svg
+                href: https://172.16.1.5:8006
+                description: pve4
+                widget:
+                  type: proxmox
+                  url: https://172.16.1.5:8006
+                  username: "{{HOMEPAGE_VAR_PROXMOX_USER}}"
+                  password: "{{HOMEPAGE_VAR_PROXMOX_PASS}}"
+                  node: pve4
+
+        - Storage:
+            - Volume-1:
+                icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/synology-light.svg
+                href: https://172.16.1.250:5001/
+                description: Backup
+                widget:
+                  type: diskstation
+                  url: https://172.16.1.250:5001/
+                  username: "{{HOMEPAGE_VAR_NAS_USER}}"
+                  password: "{{HOMEPAGE_VAR_NAS_PASS}}"
+                  volume: volume_1
+            - Volume-2:
+                icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/synology-light.svg
+                href: https://172.16.1.250:5001/
+                description: Media
+                widget:
+                  type: diskstation
+                  url: https://172.16.1.250:5001/
+                  username: "{{HOMEPAGE_VAR_NAS_USER}}"
+                  password: "{{HOMEPAGE_VAR_NAS_PASS}}"
+                  volume: volume_2
+            - PBS:
+                icon: proxmox.svg
+                href: https://172.16.1.12:8007/
+                description: Proxmox Backup
+                widget:
+                  type: proxmoxbackupserver
+                  url: https://172.16.1.12:8007
+                  username: "{{HOMEPAGE_VAR_PBS_USER}}"
+                  password: "{{HOMEPAGE_VAR_PBS_PASS}}"
 
         - Media:
             - Plex:
-                icon: plex
-                href: http://172.16.1.33:32400
+                icon: plex.svg
+                href: https://plex.ragas.sh
                 description: Media Server
+                widget:
+                  type: plex
+                  url: https://plex.ragas.sh
+                  key: "{{HOMEPAGE_VAR_PLEX_KEY}}"
             - Jellyfin:
-                icon: jellyfin
+                icon: jellyfin.svg
                 href: http://172.16.1.30:8096
-                description: Media Server
+                description: Jellyfin
+                widget:
+                  type: jellyfin
+                  url: http://172.16.1.30:8096
+                  key: "{{HOMEPAGE_VAR_JELLYFIN_KEY}}"
+                  enableBlocks: true
+                  enableNowPlaying: true
+                  enableUser: true
+            - Tautulli:
+                icon: tautulli.svg
+                href: http://172.16.1.33:8181
+                description: Plex stats
+                widget:
+                  type: tautulli
+                  url: http://172.16.1.33:8181
+                  key: "{{HOMEPAGE_VAR_TAUTULLI_KEY}}"
+
+        - Requests:
+            - Overseerr:
+                icon: overseerr.svg
+                href: https://request.ragas.sh
+                description: Plex Requests
+                widget:
+                  type: overseerr
+                  url: http://172.16.1.31:5055
+                  key: "{{HOMEPAGE_VAR_OVERSEERR_KEY}}"
+            - Jellyseerr:
+                icon: jellyseerr.svg
+                href: http://172.16.1.31:5056
+                description: Jelly Requests
+                widget:
+                  type: jellyseerr
+                  url: http://172.16.1.31:5056
+                  key: "{{HOMEPAGE_VAR_JELLYSEERR_KEY}}"
+
+        - Media Management:
             - Sonarr:
-                icon: sonarr
+                icon: sonarr.svg
                 href: http://172.16.1.31:8989
                 description: TV Shows
+                widget:
+                  type: sonarr
+                  url: http://172.16.1.31:8989
+                  key: "{{HOMEPAGE_VAR_SONARR_KEY}}"
             - Radarr:
-                icon: radarr
+                icon: radarr.svg
                 href: http://172.16.1.31:7878
                 description: Movies
+                widget:
+                  type: radarr
+                  url: http://172.16.1.31:7878
+                  key: "{{HOMEPAGE_VAR_RADARR_KEY}}"
+            - Prowlarr:
+                icon: prowlarr.svg
+                href: http://172.16.1.31:9696
+                description: Indexers
+                widget:
+                  type: prowlarr
+                  url: http://172.16.1.31:9696
+                  key: "{{HOMEPAGE_VAR_PROWLARR_KEY}}"
 
-        - Infrastructure:
-            - Proxmox:
-                icon: proxmox
-                href: https://172.16.1.2:8006
-                description: Hypervisor Cluster
-            - TrueNAS:
-                icon: truenas
-                href: http://172.16.1.250
-                description: Network Storage
-            - UniFi:
-                icon: unifi
+        - Network:
+            - OpnSense:
+                icon: opnsense.svg
+                href: http://172.16.1.1/
+                description: Firewall
+                widget:
+                  type: opnsense
+                  url: https://172.16.1.1/
+                  username: "{{HOMEPAGE_VAR_OPNSENSE_USER}}"
+                  password: "{{HOMEPAGE_VAR_OPNSENSE_PASS}}"
+            - Adguard:
+                icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/adguard-home.svg
+                href: https://172.16.1.11
+                description: Adblocker
+                widget:
+                  type: adguard
+                  url: https://172.16.1.11
+                  username: "{{HOMEPAGE_VAR_ADGUARD_USER}}"
+                  password: "{{HOMEPAGE_VAR_ADGUARD_PASS}}"
+            - qBittorrent:
+                icon: qbittorrent.svg
+                href: http://172.16.1.32:8080
+                description: Downloads
+                widget:
+                  type: qbittorrent
+                  url: http://172.16.1.32:8080
+                  username: "{{HOMEPAGE_VAR_QBIT_USER}}"
+                  password: "{{HOMEPAGE_VAR_QBIT_PASS}}"
+            - Cloudflare:
+                icon: cloudflare.svg
+                href: https://one.dash.cloudflare.com
+                description: Tunnel
+                widget:
+                  type: cloudflared
+                  accountid: "{{HOMEPAGE_VAR_CF_ACCOUNT}}"
+                  tunnelid: "{{HOMEPAGE_VAR_CF_TUNNEL}}"
+                  key: "{{HOMEPAGE_VAR_CF_KEY}}"
+            - Uptime-Kuma:
+                icon: uptime-kuma.svg
+                href: http://172.16.1.249:3001
+                description: Monitoring
+                widget:
+                  type: uptimekuma
+                  url: http://172.16.1.249:3001
+                  slug: 1
+            - Unifi:
+                icon: unifi.svg
                 href: https://172.16.1.253:8443
-                description: Network Controller
+                description: Network
+                widget:
+                  type: unifi
+                  url: https://172.16.1.253:8443
+                  site: home
+                  username: "{{HOMEPAGE_VAR_UNIFI_USER}}"
+                  password: "{{HOMEPAGE_VAR_UNIFI_PASS}}"
 
       widgets:
+        - resources:
+            cpu: true
+            memory: true
+            disk: /
+        - datetime:
+            text_size: xl
+            format:
+              timeStyle: short
+              dateStyle: long
+        - openweathermap:
+            label: San Mateo
+            units: metric
+            provider: openweathermap
+            apiKey: "{{HOMEPAGE_VAR_WEATHER_KEY}}"
+            cache: 5
         - kubernetes:
             cluster:
               show: true
@@ -113,26 +283,52 @@ spec:
               cpu: true
               memory: true
               showLabel: true
-        - datetime:
-            text_size: xl
-            format:
-              dateStyle: long
-              timeStyle: short
-              hourCycle: h12
 
       settings:
-        title: Ragas Homelab
-        favicon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/heimdall.png
+        title: Sagar's Dashboard
+        background:
+          image: https://images.unsplash.com/photo-1505699261378-c372af38134c?q=80&w=3270&auto=format&fit=crop
+          blur: sm
+          saturate: 50
+          brightness: 100
+          opacity: 50
         theme: dark
-        color: slate
-        headerStyle: clean
+        color: zinc
+        disableCollapse: true
+        useEqualHeights: true
+        headerStyle: boxed
+        hideVersion: true
+        showStats: true
+        statusStyle: dot
+        hideErrors: true
         layout:
-          Kubernetes:
-            style: row
-            columns: 3
-          Media:
+          Hypervisor:
+            header: true
             style: row
             columns: 4
-          Infrastructure:
+            icon: proxmox.svg
+          Storage:
+            header: true
             style: row
             columns: 3
+            icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/synology-light.svg
+          Media:
+            header: true
+            style: row
+            columns: 3
+            icon: plex.svg
+          Requests:
+            header: true
+            style: row
+            columns: 2
+            icon: overseerr.svg
+          Media Management:
+            header: true
+            style: row
+            columns: 3
+            icon: sonarr.svg
+          Network:
+            header: true
+            style: row
+            columns: 4
+            icon: ubiquiti.svg

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - httproute.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/default/homepage/app/secret.sops.yaml
+++ b/kubernetes/apps/default/homepage/app/secret.sops.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: homepage-config
+type: Opaque
+stringData:
+  HOMEPAGE_VAR_PROXMOX_USER: ENC[AES256_GCM,data:0RnMThnEK5Vc/vCAUxhlRQ==,iv:msOe+soxoPs0mnhr0RBxXFIoMGcfy3+vxYlu2EjKNEg=,tag:vFj/cnk8nM1tGXRu0c3VoA==,type:str]
+  HOMEPAGE_VAR_PROXMOX_PASS: ENC[AES256_GCM,data:BrwpkXLSIbeQaLvOswi1eQmJUS3KyCZMfdpm4JOsad8oyLGE,iv:hb1sq5EpQfSBxDG/K/qCCjNQlQkfQY8T1mde5GW+qfY=,tag:EA74XGjkIvd18N3WDxaWQw==,type:str]
+  HOMEPAGE_VAR_NAS_USER: ENC[AES256_GCM,data:7RNzBAPoe5mi/4a/,iv:18yPsQ3oVbafqy7FLQyc+w+aOL5OznWWRbbhQTZjN9g=,tag:o0wgLA3iPWwhPuQxwNiGYA==,type:str]
+  HOMEPAGE_VAR_NAS_PASS: ENC[AES256_GCM,data:wUG6kHhpvmiNbT1s/tkUzsQwVt4=,iv:oxuHjqReg7qbPzQS2PDosQgv/6lh+CrQB3vog2b3WiE=,tag:v5lV/gHlm0nT4DAKCfX2kA==,type:str]
+  HOMEPAGE_VAR_PBS_USER: ENC[AES256_GCM,data:YHVsmq6EmZZoZdWMPvfW08k=,iv:V/ysl6Moon4vIIKUMvI3va6IIRwmBpZq2xia6fw93mg=,tag:W4LjPtYLo5VNoUzv5ZsTKg==,type:str]
+  HOMEPAGE_VAR_PBS_PASS: ENC[AES256_GCM,data:Jo0cBXlJ6cwRRQBo+GQwPU56iJ7sTXZv76XvuiWdecT2E/CV,iv:DjQ6DFM4bG7MG5NpTCrelUqohsRSBSvQQyhD3YfR8r0=,tag:FHw470EvamTjln0lZtB0qA==,type:str]
+  HOMEPAGE_VAR_PLEX_KEY: ENC[AES256_GCM,data:FZKvSwYTE2VSMNvmXu86OgA/c28=,iv:21sDNXlrzgQhkSu6LvbIHzARHyqOJVYewhx5mGKCpi8=,tag:ohB0vP+Vs2caqLTmyWnhqQ==,type:str]
+  HOMEPAGE_VAR_JELLYFIN_KEY: ENC[AES256_GCM,data:AvHWVlRhfiJ0MS1A8HSJoTcrmGGxHJPoUU4Gcr3L8gs=,iv:2XO3k/f3bXwmwFUD+fH0O5ZZqRINi2i39b8vJf+ULdI=,tag:SLtrOFD7IfzpJWnp/8mfIA==,type:str]
+  HOMEPAGE_VAR_TAUTULLI_KEY: ENC[AES256_GCM,data:qkAfzbNxWRm4mAk7rC9SuK1AepmyBuMyDL1fXL6Evjo=,iv:E6q8Qc4j20UyL5aEXZKnFSrPn1XzWNwM0tncTmOji6Q=,tag:zL1/IaMKF+2MsV/XFnR9Nw==,type:str]
+  HOMEPAGE_VAR_OVERSEERR_KEY: ENC[AES256_GCM,data:3aCyNbRdNhuRL7KR9mD5fnevfz8GXZoHclgG9VF2YQ4cEyJUrjZ86plC5JIWnWyryPH8w49+wyOjrYz+jGGIWhhejDI=,iv:7YYaXQ0ws3NcFV/qc3I/8PCDbxdQHgMPP/SM0BnX1B8=,tag:40GdcUjoEVs0+QU6/SkeLQ==,type:str]
+  HOMEPAGE_VAR_JELLYSEERR_KEY: ENC[AES256_GCM,data:hmRlg0PmmsrRYhy2flN7XX+ICvJf+LASihkCAbcl0eM9/lKUf0k8dQURqttSE/PFsvNGq3WjfO9pLXg5cOhBsnKLL2s=,iv:xa5/fzk4N8kwq1Yb3MD/HpqIiM86m4IOX6OO9IQMgyQ=,tag:xf9RrQ7dUMScdQ7aahJjrQ==,type:str]
+  HOMEPAGE_VAR_SONARR_KEY: ENC[AES256_GCM,data:OJnj/Xg4FcGo73Vc4ObFferibW9CycdHor95VZYP4dI=,iv:kzE2ZVu00liFQb4nUN2umq2t0P2UejkCOQiLQhGAQdA=,tag:xmTDW+sxQJODtdRiXuW6HA==,type:str]
+  HOMEPAGE_VAR_RADARR_KEY: ENC[AES256_GCM,data:8cKl9zcbMm/FtWN2brnEA0tprrG7N5QncGVz0EtyzeA=,iv:XzXsfGRiQwUVUZuogQng6fAEYTYLGwq+K9yksNTV0Xs=,tag:NWLILGYPsz8+6tiht5KTIA==,type:str]
+  HOMEPAGE_VAR_PROWLARR_KEY: ENC[AES256_GCM,data:DlHYzwAVR85PyM2vrflos4TL5vYutC+i1hcX1HU+Xsc=,iv:YXCPzN9Y2TKAuaLqK8LZox7Hj4p9JcF3eU8n0fsZkmI=,tag:sv9x59EczDnnfOpFi0Kk4g==,type:str]
+  HOMEPAGE_VAR_OPNSENSE_USER: ENC[AES256_GCM,data:q8sby0ApQ9M1DP1hxCEq/NVkY71lAdEVmXnT1+n0/CE2ib5GopRTcGUqEUbEUZmXUUJBIqCfY2nq2IthXZGIrYTNsluDygyRZ7WI43UccWs=,iv:wuy/f+2fNF3trfNh9tX1cR8sKI/KtK3tmCMLiwXQd9k=,tag:SeVs7p7duO0jyaDCv9DhBQ==,type:str]
+  HOMEPAGE_VAR_OPNSENSE_PASS: ENC[AES256_GCM,data:eDwO/zUk9iDY4zvpzAo6lxUP+RIb3Fg6QXvhIZ6fZ7kvPGATvgP795scRfb6GsYSGWhSiBLefdIszp4rHWs8glP4itPUdU/zWeSsqn5LKQM=,iv:IoXDqDG/S0EzOHngtrJQYBJyhXF2Ihl2Z4Q8t9+eAcA=,tag:1ZNepJaJ5y4CB+xlOmWCJw==,type:str]
+  HOMEPAGE_VAR_ADGUARD_USER: ENC[AES256_GCM,data:TVeB+w==,iv:u4g6Qh0yCDUkNzjQT3XpSsJd3NIMoNXOQE5aW7l9FA4=,tag:oXO/TnBeFgwM6lRGNWzowA==,type:str]
+  HOMEPAGE_VAR_ADGUARD_PASS: ENC[AES256_GCM,data:lCdCItczrsU=,iv:236+w1s6tTWKAVUU4QQf/sJZ9cB54PeH7UhZjg0r5dg=,tag:L9OKYstnUtX+O7as0plrkA==,type:str]
+  HOMEPAGE_VAR_QBIT_USER: ENC[AES256_GCM,data:ohhP8qg=,iv:JV6iyIumZMeXEwwqk7NVH1ZP+NRc6Ppkux0Wyk0tfIM=,tag:mJ731vvWEGWJHBR5IGAkLg==,type:str]
+  HOMEPAGE_VAR_QBIT_PASS: ENC[AES256_GCM,data:oVxGaVUoLIY=,iv:xbgrbU5JIF4MppTFcK8Imvxn7C3Jt6nSfuSVZOCqTtY=,tag:IRUg+9GjLtnsIoj9XmVcJQ==,type:str]
+  HOMEPAGE_VAR_CF_ACCOUNT: ENC[AES256_GCM,data:W7J4qMxOOsSF8rSvfp67tMQ0+jM6dL+BiGzbCxgr3lc=,iv:b7YNwR4TM8DxWFY2lio8w4/Hjm/nJdaNQLTl9ZOMP1g=,tag:q0o+qkOHA+AuHeqY4AIHWA==,type:str]
+  HOMEPAGE_VAR_CF_TUNNEL: ENC[AES256_GCM,data:7fvvLkNaicfttynDsN78nSv1v3R/JzIoRJA2HHGghOQLDYIg,iv:NdhmhJURguTcSrlNSpDloTQ9v/v5hJsjf2mliXI/T7E=,tag:g5nqQ1T9EzgLUEGDEU8PTQ==,type:str]
+  HOMEPAGE_VAR_CF_KEY: ENC[AES256_GCM,data:KBIvQ++xqNSKCCKhcriPyEHvzJe0GPQ89hcZdQoa44V4j1amdzVSnw==,iv:sOUTlTvL3wepzWknOC5m27m0ZO5z9YrePunhtRtm4cY=,tag:dToDHMJA8nXVcxJDuhG38w==,type:str]
+  HOMEPAGE_VAR_TRAEFIK_USER: ENC[AES256_GCM,data:zia6cGs=,iv:+XY26YndSCPsOCydXNja6eY0kOOZvPXwyuQ6crAuXoc=,tag:ku2raO70Vtx1uXZQvu1TlQ==,type:str]
+  HOMEPAGE_VAR_TRAEFIK_PASS: ENC[AES256_GCM,data:CWJz7oCwucE=,iv:Blq7p8M1C8h+ySk4eVzg+q/PRzkDqMakKP9OXJxORWc=,tag:0ej83HFJ0mJQKcmXF0cr6g==,type:str]
+  HOMEPAGE_VAR_UNIFI_USER: ENC[AES256_GCM,data:y+m0F4RjerTR10jcMPJW,iv:CyqRXUaa9fSE4mYPYWdkGZxrds4NszeJvl8FTJ37Lis=,tag:erBJfnnYHoJvdOnoBb+eCQ==,type:str]
+  HOMEPAGE_VAR_UNIFI_PASS: ENC[AES256_GCM,data:EvU1USpLj1Q=,iv:1Bd3tAHfhBtLFzrQIJpDNvdXCU712D9/CDY2JT/k+4o=,tag:oQvoLlrXGDYJMb1hnjwzKQ==,type:str]
+  HOMEPAGE_VAR_WEATHER_KEY: ENC[AES256_GCM,data:9caHfpRBKbatQs4/st/xQQOAzDXnQvzCUpfqQINDvdA=,iv:83qlJuk1i8SR+ZmdS+XU5nIbgiG33JOVuEHEg32rEkY=,tag:TU4ZGlr7VS0uUcfFOb94BQ==,type:str]
+sops:
+  age:
+    - recipient: age1v5nv69s859gf2494tevycyflcyezltjgvcss75ctgpdpv6wtu3fquywey3
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnTkxzbXJhMjhpd2U1ZG5F
+        NDljR1ljVy9LcG45clE3bHlKczFZUmdwL3gwClF4MlViaXd2SUNZb1ByTFpkeXZ1
+        Rk9xVHhMbDUwcXJ4QzcvK3MyTTdMbGsKLS0tIGxKNGg2S0RvWmwzU1dZZ2RzeU12
+        WG9sak5mRkhleitxZ3QrcEJjbE1WeTAKgxYj/1ZABamUnkQUdGssjg2K0M3tYhIv
+        nAnG9M8xbQNHBQ/b+SdRibunShH+7Qq613GmYTWDSNORv1eSag095Q==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-01-04T04:59:29Z"
+  mac: ENC[AES256_GCM,data:bmh3SdxFwmkLgBDQNnEXWo5mKMfxbRK7N5WHJ35WkMxRkqgixXWjjE00+V5M+fEUV15vgjfi2ZGYGKkoyEOonwv9T04jXe9J0J5vMjn3tZloU0urrxxOc2mTQJQswkLIIz63uGyyfPgVHCZrMBBejReSLC/LpaoE7wCoSaVnyyI=,iv:mU7QkbYJrwgWIYhctkGHguzLJDgulloaU0MMsq9LaQ0=,tag:ltRWw0T7Pjjjt7mNjy6usQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0


### PR DESCRIPTION
## Summary
Migrate Homepage configuration from Runtipi LXC to Kubernetes with full widget support.

## Changes
- Full Runtipi Homepage config with all widgets:
  - Proxmox cluster monitoring (4 nodes)
  - NAS/Synology volume monitoring
  - PBS backup monitoring
  - Media stack (Plex, Jellyfin, Tautulli)
  - Arr stack (Sonarr, Radarr, Prowlarr)
  - Request services (Overseerr, Jellyseerr)
  - Network (OpnSense, AdGuard, Unifi, qBittorrent)
  - Cloudflare tunnel status
  - Weather widget
  - Kubernetes cluster widget
- SOPS-encrypted secrets for all API keys and passwords
- Custom styling (dark theme, background image)

## Testing
- [ ] Flux reconciles successfully
- [ ] Homepage loads at home.ragas.cc
- [ ] All widgets show data
- [ ] Secrets are properly decrypted

## Related
Migrating from Runtipi on 172.16.1.7 to Kubernetes cluster.