### PR TITLE
docs: refresh architecture pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,42 +6,47 @@ Welcome to the comprehensive documentation for the Ragas Homelab Kubernetes clus
 
 | Resource | URL | Description |
 |----------|-----|-------------|
-| Kubernetes Dashboard | https://k8s.ragas.cc | Cluster management |
 | Homepage | https://home.ragas.cc | Service dashboard |
 | Grafana | https://grafana.ragas.cc | Monitoring & metrics |
+| Prometheus | https://prometheus.ragas.cc | Metrics & alerting |
+| Alertmanager | https://alertmanager.ragas.cc | Alert routing |
 | Docs | https://docs.ragas.cc | This documentation |
 
 ## Architecture Overview
 
 - **Platform**: Talos Linux v1.11.5
 - **Kubernetes**: v1.34.2
-- **GitOps**: Flux v2.7.5
+- **GitOps**: Flux v2
 - **CNI**: Cilium (eBPF, DSR mode)
 - **Ingress**: Envoy Gateway (Gateway API)
-- **Storage**: Ceph CSI (connected to Proxmox Ceph)
+- **DNS**: bind9 + AdGuard (internal) + Cloudflare (public)
+- **Storage**: Ceph CSI (RBD + CephFS) + NFS (media/backups)
 - **Certificates**: cert-manager + Let's Encrypt
 - **CI/CD**: GitHub Actions + Droid AI automation
 
 ## Cluster Nodes
 
-| Node | Role | IP | Resources |
-|------|------|-----|-----------|
-| talos-cp-1 | Control Plane | 172.16.1.50 | 4 CPU, 8GB RAM, 100GB |
-| talos-cp-2 | Control Plane | 172.16.1.51 | 4 CPU, 8GB RAM, 100GB |
-| talos-cp-3 | Control Plane | 172.16.1.52 | 4 CPU, 8GB RAM, 100GB |
-| talos-worker-1 | Worker | 172.16.1.53 | 8 CPU, 16GB RAM, 200GB |
+| Node | Role | IP | Host | VMID |
+|------|------|-----|------|------|
+| talos-cp-1 | Control Plane | 172.16.1.50 | pve1 | 500 |
+| talos-cp-2 | Control Plane | 172.16.1.51 | pve2 | 501 |
+| talos-cp-3 | Control Plane | 172.16.1.52 | pve4 | 502 |
+| talos-worker-1 | Worker | 172.16.1.53 | pve1 | 510 |
+| talos-worker-2 | Worker | 172.16.1.54 | pve2 | 511 |
+| talos-worker-3 | Worker | 172.16.1.55 | pve3 | 512 |
+| talos-worker-4 | Worker | 172.16.1.56 | pve4 | 513 |
 
 **Cluster VIP**: 172.16.1.49
 
 ## Storage
 
-| PVC | Size | Purpose |
-|-----|------|---------|
-| prometheus-db | 50Gi | Metrics (7d retention) |
-| grafana | 10Gi | Dashboards |
-| alertmanager-db | 5Gi | Alert state |
+| Storage | Use | Notes |
+|---------|-----|-------|
+| **ceph-block (RBD)** | Databases/monitoring | RWO |
+| **ceph-filesystem (CephFS)** | App configs | RWX |
+| **NFS** | Media + backups | NAS-backed |
 
-**Backend**: Proxmox Ceph cluster via ceph-csi-rbd
+**Backend**: Proxmox Ceph cluster + NAS NFS
 
 ## Documentation Sections
 

--- a/docs/services/homepage.md
+++ b/docs/services/homepage.md
@@ -69,10 +69,7 @@ Homepage supports widgets for many services:
 
 | Service | Widget Type |
 |---------|-------------|
-| Plex | plex |
-| Sonarr | sonarr |
-| Radarr | radarr |
-| qBittorrent | qbittorrent |
+| Grafana | grafana |
 | Proxmox | proxmox |
 | AdGuard | adguard |
 | Portainer | portainer |
@@ -80,14 +77,13 @@ Homepage supports widgets for many services:
 ### Widget Example
 
 ```yaml
-- Media:
-    - Plex:
-        icon: plex
-        href: http://172.16.1.33:32400
+- Monitoring:
+    - Grafana:
+        icon: grafana
+        href: https://grafana.ragas.cc
         widget:
-          type: plex
-          url: http://172.16.1.33:32400
-          key: YOUR_PLEX_TOKEN
+          type: grafana
+          url: http://grafana.monitoring.svc.cluster.local
 ```
 
 ## Kubernetes Widget


### PR DESCRIPTION
Refreshes docs.ragas.cc architecture pages to match current cluster (nodes, DNS chain, storage classes, CI/CD workflows) and removes app-specific ARR references from the Homepage docs.