### PR TITLE
docs: add missing service pages

### DIFF
--- a/docs/services/backups.md
+++ b/docs/services/backups.md
@@ -1,0 +1,41 @@
+# Backups (Velero + Minio)
+
+The cluster uses Velero for Kubernetes backups, with an in-cluster Minio (S3-compatible) backend.
+
+## Components
+
+| Component | Namespace | Purpose |
+|-----------|-----------|---------|
+| Minio | `backup` | S3-compatible object storage for backup artifacts |
+| Velero | `backup` | Backups/restores + CSI snapshots |
+
+## How it works
+
+- Velero stores backup metadata and artifacts in the `velero` bucket in Minio.
+- Volume backups use CSI snapshots (Ceph CSI).
+- A daily scheduled backup runs via the Velero HelmRelease.
+
+## Common commands
+
+```bash
+# Back up a namespace
+velero backup create my-backup --include-namespaces default
+
+# Restore from a backup
+velero restore create --from-backup my-backup
+
+# View backups/restores
+velero backup get
+velero restore get
+```
+
+## Credentials
+
+- Minio credentials: `kubernetes/apps/backup/minio/app/secret.sops.yaml` (Secret: `minio-credentials`)
+- Velero credentials: `kubernetes/apps/backup/velero/app/secret.sops.yaml` (Secret: `velero-minio-credentials`)
+
+## Files
+
+- Minio HelmRelease: `kubernetes/apps/backup/minio/app/helmrelease.yaml`
+- Velero HelmRelease: `kubernetes/apps/backup/velero/app/helmrelease.yaml`
+- Backup namespace: `kubernetes/apps/backup/namespace.yaml`

--- a/docs/services/cloudflare-tunnel.md
+++ b/docs/services/cloudflare-tunnel.md
@@ -1,0 +1,34 @@
+# Cloudflare Tunnel
+
+Cloudflare Tunnel provides inbound access to selected public hostnames without exposing the cluster directly to the internet.
+
+## Architecture
+
+```
+Client → Cloudflare → Tunnel (cloudflared) → Envoy Gateway (envoy-external) / specific services
+```
+
+- Runs in the `network` namespace.
+- Deployed as two replicas for availability.
+
+## Configuration
+
+- HelmRelease: `kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml`
+- Credentials: `kubernetes/apps/network/cloudflare-tunnel/app/secret.sops.yaml` (Secret: `cloudflare-tunnel-secret`)
+- Ingress rules are defined in the embedded `config.yaml` in the HelmRelease values.
+
+## Observability
+
+`cloudflared` exposes a readiness endpoint on port `8080` and is scraped via a ServiceMonitor (see the HelmRelease).
+
+## Troubleshooting
+
+```bash
+# Pods / logs
+kubectl get pods -n network -l app.kubernetes.io/name=cloudflare-tunnel
+kubectl logs -n network -l app.kubernetes.io/name=cloudflare-tunnel --tail=200
+
+# Readiness check
+kubectl port-forward -n network deploy/cloudflare-tunnel 8080:8080
+curl -fsS http://127.0.0.1:8080/ready
+```

--- a/docs/services/logging.md
+++ b/docs/services/logging.md
@@ -1,0 +1,32 @@
+# Logging (Loki + Promtail)
+
+The cluster uses Loki for log storage and Promtail to ship logs from nodes/pods into Loki.
+
+## Components
+
+| Component | Namespace | Purpose |
+|-----------|-----------|---------|
+| Loki | `monitoring` | Log storage + query API |
+| Promtail | `monitoring` | Log shipping to Loki |
+
+## Grafana integration
+
+Grafana is configured with a Loki datasource via a ConfigMap.
+
+## Troubleshooting
+
+```bash
+# Loki / Promtail pods
+kubectl get pods -n monitoring -l app.kubernetes.io/name=loki
+kubectl get pods -n monitoring -l app.kubernetes.io/name=promtail
+
+# Recent logs
+kubectl logs -n monitoring -l app.kubernetes.io/name=loki --tail=200
+kubectl logs -n monitoring -l app.kubernetes.io/name=promtail --tail=200
+```
+
+## Files
+
+- Loki HelmRelease: `kubernetes/apps/monitoring/loki/app/helmrelease.yaml`
+- Promtail HelmRelease: `kubernetes/apps/monitoring/promtail/app/helmrelease.yaml`
+- Grafana datasource: `kubernetes/apps/monitoring/kube-prometheus-stack/app/loki-datasource.yaml`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,8 +69,11 @@ nav:
   - Services:
       - Homepage: services/homepage.md
       - Monitoring: services/monitoring.md
+      - Logging: services/logging.md
+      - Backups: services/backups.md
       - Cert Manager: services/cert-manager.md
       - DNS & Ingress: services/networking.md
+      - Cloudflare Tunnel: services/cloudflare-tunnel.md
   - Guides:
       - Deploy a Service: guides/deploy-service.md
       - Image Automation: guides/image-automation.md


### PR DESCRIPTION
Adds documentation pages for Cloudflare Tunnel, backups (Velero + Minio), and logging (Loki + Promtail), and wires them into the MkDocs navigation.