### PR TITLE
ci: prepare repo for protected main

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,9 +11,9 @@
   suppressNotifications: [
     'prEditedNotification',
   ],
-  // Auto-merge directly to main without PRs for most updates
+  // Auto-merge via PRs for most updates (required for protected branches)
   automerge: true,
-  automergeType: 'branch',
+  automergeType: 'pr',
   platformAutomerge: true,
   flux: {
     managerFilePatterns: [
@@ -35,7 +35,7 @@
       description: 'Auto-merge all patch and minor updates',
       matchUpdateTypes: ['patch', 'minor'],
       automerge: true,
-      automergeType: 'branch',
+      automergeType: 'pr',
     },
     {
       description: 'Major updates need manual review (create PR)',

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Auto-merge GitHub Actions updates
         if: steps.metadata.outputs.package-ecosystem == 'github_actions'
-        run: gh pr merge --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ flowchart LR
 
 ### Branch Protection
 
-GitHub branch protection is currently **not enabled** for `main`. The preferred workflow is still PRs + CI (with auto-merge used for many bot PRs).
+GitHub branch protection is enabled for `main`: changes merge via PRs, and the Validate checks must pass.
 
 ```mermaid
 flowchart LR
@@ -191,7 +191,7 @@ Dependency and image tag updates are handled via Renovate/Dependabot. (Optional)
 ```mermaid
 flowchart LR
   registries["Registries / Charts"] --> bots["Renovate / Dependabot"]
-  bots --> pr["PR to main (or direct)"]
+  bots --> pr["PR to main"]
   pr --> ci["CI (validate)"]
   ci -->|"PASS"| merge["Merge / auto-merge"]
   merge --> flux["Flux GitOps"]


### PR DESCRIPTION
Updates Renovate and Dependabot automation so it continues working once  is protected (PR-based automerge + Dependabot merges wait for required checks).