### PR TITLE
fix(ci): enable sticky comment for droid-review

### DIFF
--- a/.github/workflows/droid-review.yaml
+++ b/.github/workflows/droid-review.yaml
@@ -35,3 +35,4 @@ jobs:
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
+          use_sticky_comment: true


### PR DESCRIPTION
## Problem
The droid-review check was failing with a 404 error when trying to update the placeholder comment.

## Root Cause
Race condition: the droid AI deletes its own "Droid is working..." placeholder comment as cleanup before posting the final review, but the post-processing step expects that comment to still exist to add a job link.

## Fix
Enable `use_sticky_comment: true` which should preserve the comment across droid execution.

## Related
- Fixes failing check on PR #104