### PR TITLE
feat(apps): add MediaManager deployment

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - ./sonarr/ks.yaml
   - ./speedtest-tracker/ks.yaml
   - ./unpackerr/ks.yaml
+  - ./mediamanager/ks.yaml

--- a/kubernetes/apps/default/mediamanager/app/configmap.yaml
+++ b/kubernetes/apps/default/mediamanager/app/configmap.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mediamanager-config
+  namespace: default
+data:
+  config.toml: |
+    [misc]
+    frontend_url = "https://media.ragas.cc"
+    cors_urls = ["https://media.ragas.cc"]
+    image_directory = "/data/images"
+    tv_directory = "/media/tv"
+    movie_directory = "/media/movies"
+    torrent_directory = "/media/downloads"
+    development = false
+
+    [[misc.tv_libraries]]
+    name = "TV Shows"
+    path = "/media/tv"
+
+    [[misc.movie_libraries]]
+    name = "Movies"
+    path = "/media/movies"
+
+    [database]
+    host = "postgres.database.svc.cluster.local"
+    port = 5432
+    user = "tipi"
+    dbname = "mediamanager"
+
+    [auth]
+    email_password_resets = false
+    session_lifetime = 86400
+    admin_emails = ["admin@ragas.cc"]
+
+    [auth.openid_connect]
+    enabled = false
+
+    [notifications]
+    [notifications.smtp_config]
+    smtp_host = ""
+    smtp_port = 587
+    smtp_user = ""
+    smtp_password = ""
+    from_email = ""
+    use_tls = true
+
+    [notifications.email_notifications]
+    enabled = false
+    emails = []
+
+    [notifications.gotify]
+    enabled = false
+    api_key = ""
+    url = ""
+
+    [notifications.ntfy]
+    enabled = false
+    url = ""
+
+    [notifications.pushover]
+    enabled = false
+    api_key = ""
+    user = ""
+
+    [torrents]
+    [torrents.qbittorrent]
+    enabled = true
+    host = "http://172.16.1.32"
+    port = 8080
+    username = "admin"
+    password = ""
+
+    [torrents.transmission]
+    enabled = false
+    username = ""
+    password = ""
+    https_enabled = false
+    host = ""
+    port = 9091
+    path = "/transmission/rpc"
+
+    [torrents.sabnzbd]
+    enabled = false
+    host = ""
+    port = 8080
+    api_key = ""
+    base_path = "/api"
+
+    [indexers]
+    [indexers.prowlarr]
+    enabled = true
+    url = "http://prowlarr.default.svc.cluster.local:9696"
+    api_key = ""
+    timeout_seconds = 60
+
+    [indexers.jackett]
+    enabled = false
+    url = ""
+    api_key = ""
+    indexers = []
+    timeout_seconds = 60
+
+    [[indexers.title_scoring_rules]]
+    name = "prefer_h265"
+    keywords = ["h265", "hevc", "x265", "h.265", "x.265"]
+    score_modifier = 100
+    negate = false
+
+    [[indexers.title_scoring_rules]]
+    name = "avoid_cam"
+    keywords = ["cam", "ts", "hdcam"]
+    score_modifier = -10000
+    negate = false
+
+    [[indexers.indexer_flag_scoring_rules]]
+    name = "prefer_freeleech"
+    flags = ["freeleech", "freeleech75"]
+    score_modifier = 100
+    negate = false
+
+    [[indexers.indexer_flag_scoring_rules]]
+    name = "reject_nuked"
+    flags = ["nuked"]
+    score_modifier = -10000
+    negate = false
+
+    [[indexers.scoring_rule_sets]]
+    name = "default"
+    libraries = ["ALL_TV", "ALL_MOVIES"]
+    rule_names = ["prefer_h265", "avoid_cam", "reject_nuked", "prefer_freeleech"]
+
+    [metadata]
+    [metadata.tmdb]
+    tmdb_relay_url = "https://metadata-relay.dorninger.co/tmdb"
+    primary_languages = [""]
+    default_language = "en"
+
+    [metadata.tvdb]
+    tvdb_relay_url = "https://metadata-relay.dorninger.co/tvdb"

--- a/kubernetes/apps/default/mediamanager/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mediamanager/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mediamanager
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: default
+  values:
+    controllers:
+      mediamanager:
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maxdorninger/mediamanager/mediamanager
+              tag: latest
+            env:
+              TZ: America/Los_Angeles
+              CONFIG_DIR: /app/config
+            envFrom:
+              - secretRef:
+                  name: mediamanager-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &port 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                add: ["CHOWN", "SETGID", "SETUID", "DAC_OVERRIDE", "FOWNER"]
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+
+    service:
+      app:
+        controller: mediamanager
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      config:
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: mediamanager-config
+        globalMounts:
+          - path: /app/config
+      config-file:
+        enabled: true
+        type: configMap
+        name: mediamanager-config
+        globalMounts:
+          - path: /app/config/config.toml
+            subPath: config.toml
+            readOnly: true
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: mediamanager-config
+        globalMounts:
+          - path: /data/images
+            subPath: images
+      media:
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: media-nfs
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/default/mediamanager/app/httproute.yaml
+++ b/kubernetes/apps/default/mediamanager/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mediamanager
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - "media.ragas.cc"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mediamanager
+          port: 8000

--- a/kubernetes/apps/default/mediamanager/app/kustomization.yaml
+++ b/kubernetes/apps/default/mediamanager/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - configmap.yaml
+  - secret.sops.yaml
+  - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/default/mediamanager/app/pvc.yaml
+++ b/kubernetes/apps/default/mediamanager/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mediamanager-config
+  namespace: default
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/default/mediamanager/app/secret.sops.yaml
+++ b/kubernetes/apps/default/mediamanager/app/secret.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mediamanager-secret
+  namespace: default
+type: Opaque
+stringData:
+  MEDIAMANAGER_AUTH__TOKEN_SECRET: ENC[AES256_GCM,data:0PSE91so+LnIuRtegUEsUwxaZze++4oP5gI6iG7VOIpRbJDLb9XevXFqMYccrCR+hCqb8N0JwuPbF9h0sYYl7A==,iv:OtjqBkS+08tzFDUqTHHYJqGMrOFKXo5RjV7r8D7atEI=,tag:ZpzsQ/MNyQqLwFej9l0ERA==,type:str]
+  MEDIAMANAGER_DATABASE__PASSWORD: ENC[AES256_GCM,data:F63d+RwgzYqRvOY5jtJzoBtqKAEKXFgDv1pGSpYmrcc=,iv:ybcVOoxtF0fzCb6Zek4oAiKkjwlb8uNq+oik5Vcw94I=,tag:OhJwo3dW9IR4Z8qe4jTRWw==,type:str]
+sops:
+  age:
+    - recipient: age1v5nv69s859gf2494tevycyflcyezltjgvcss75ctgpdpv6wtu3fquywey3
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5dHZpUFFha2VjSXBUeFJC
+        NCtyVDFvRVVQRjgwV2V4UlhwQTk4NkNlREN3CkZPbG5UYnE1b1JnWFdQcU9kOW42
+        eEJwNG5OWGNDdzczWG9EWHBBeHNja00KLS0tIFVUTDdHaXJmSEJvTFY4aWxhY3dO
+        U3lKOFZJeG5KRmI4K3FJdWRXc214c00KLmkaR2vcDhmmjaglRQAf0NHRPJBO6ZZB
+        lGB1hwo8qjGuP4Nv1yZgmmVOcPO7EBGnaX4+tHuldYjGJj2oQwoR2Q==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-01-10T20:37:51Z"
+  mac: ENC[AES256_GCM,data:W7w0CFAklTJft5HkewGU1uxuGHkHLEqPAtooGL1tlsw6NWBGwo8mK6EpjLiePkaNgbzyFL2VQNnuz8nUGDITTDaE4VZKGZtRWFziwneiRxghvz2Eu7ioVofep6zcp1mNv8Bns5r+qb5aQ6KU+2/2kdvMltGdeZbkwo0CdHQwY7A=,iv:M+Lo7WaQkSTpXXgDvAZtoAGHdnvY85eB5Of32LbvTMQ=,tag:19y2+1v5EcYIkQ1im+jJbQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/default/mediamanager/ks.yaml
+++ b/kubernetes/apps/default/mediamanager/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mediamanager
+  namespace: default
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: mediamanager
+  path: ./kubernetes/apps/default/mediamanager/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: media-storage


### PR DESCRIPTION
## Summary
Deploy MediaManager as a test replacement for the Arr stack (Sonarr, Radarr, Seerr).

## Changes
- Add new `mediamanager` app to `default` namespace
- URL: `https://media.ragas.cc`
- Uses existing shared PostgreSQL database (new `mediamanager` DB)
- CephFS storage for config and images (5Gi)
- NFS mount for media library
- Integrates with:
  - qBittorrent on LXC (172.16.1.32:8080)
  - Prowlarr on K8s for indexer proxy

## Testing
This is a **test deployment** that runs alongside the existing Arr stack. No changes to Sonarr/Radarr/Prowlarr.

After deployment:
1. Access `https://media.ragas.cc`
2. Check pod logs for auto-generated admin credentials
3. Configure qBittorrent and Prowlarr connections
4. Import existing media library if it works well

## Files Added
```
kubernetes/apps/default/mediamanager/
├── ks.yaml
└── app/
    ├── kustomization.yaml
    ├── helmrelease.yaml
    ├── httproute.yaml
    ├── pvc.yaml
    ├── configmap.yaml
    └── secret.sops.yaml
```