### PR TITLE
feat(apps): add Agregarr Plex Collections manager

### DIFF
--- a/kubernetes/apps/default/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/agregarr/app/helmrelease.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agregarr
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: default
+  values:
+    controllers:
+      agregarr:
+        replicas: 1
+        containers:
+          app:
+            image:
+              repository: agregarr/agregarr
+              tag: latest
+            env:
+              TZ: America/Los_Angeles
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 7171
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 60
+                  timeoutSeconds: 1
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+
+    service:
+      app:
+        controller: agregarr
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      config:
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: agregarr-config
+        globalMounts:
+          - path: /app/config

--- a/kubernetes/apps/default/agregarr/app/httproute.yaml
+++ b/kubernetes/apps/default/agregarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agregarr
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - "agg.ragas.cc"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: agregarr
+          port: 7171

--- a/kubernetes/apps/default/agregarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/agregarr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/default/agregarr/app/pvc.yaml
+++ b/kubernetes/apps/default/agregarr/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agregarr-config
+  namespace: default
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/default/agregarr/ks.yaml
+++ b/kubernetes/apps/default/agregarr/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agregarr
+  namespace: default
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: agregarr
+  path: ./kubernetes/apps/default/agregarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - ./sonarr/ks.yaml
   - ./speedtest-tracker/ks.yaml
   - ./unpackerr/ks.yaml
+  - ./agregarr/ks.yaml


### PR DESCRIPTION
## Summary
Deploys Agregarr - a Plex Collections manager that syncs collections from various sources.

## What is Agregarr?
- Manages Plex collections from Trakt, IMDb, TMDB, Letterboxd, MDBList, etc.
- Keeps Home/Recommended screens fresh with rotating collections
- Can request missing media via Sonarr/Radarr or Seerr
- Generates collections from Tautulli stats

## Resources Created
- PVC: 2Gi CephFS for config (SQLite DB embedded)
- HelmRelease: agregarr/agregarr:latest on port 7171
- HTTPRoute: agg.ragas.cc → envoy-internal
- DNS: agg.ragas.cc → 172.16.1.61 (already added to bind9)

## Post-Deploy
Configure in UI:
- Plex server connection
- Sonarr/Radarr integration
- List sources (Trakt, IMDb, etc.)