### PR TITLE
fix: increase Huntarr memory limit to 768Mi

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
             resources:
               requests:
                 cpu: 25m
-                memory: 128Mi
+                memory: 256Mi
               limits:
-                memory: 512Mi
+                memory: 768Mi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Problem
Huntarr is repeatedly OOMKilled on talos-worker-4. Current memory usage is **472Mi** with a **512Mi** limit — leaving almost no headroom. The pod has been OOMKilled 5 times in the past 47 minutes.

## Fix
- Memory request: 128Mi → **256Mi** (reflects actual baseline usage)
- Memory limit: 512Mi → **768Mi** (provides ~50% headroom above peak)

## Context
- cilium-r49nm on worker-4 shows 57 restarts but has been **stable since Feb 3** (4+ days). This is the known incident from prior OOM during BPF compilation — no action needed.
- All other cluster components are healthy: 7/7 nodes Ready, 114 pods, all Flux reconciliations passing, Ceph HEALTH_OK, NFS healthy.