### PR TITLE
security: add Pod Security Standards to all namespaces

### DIFF
--- a/kubernetes/apps/backup/namespace.yaml
+++ b/kubernetes/apps/backup/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: backup
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: cert-manager
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -3,3 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: database
+  labels:
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: default
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: flux-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: kube-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/monitoring/namespace.yaml
+++ b/kubernetes/apps/monitoring/namespace.yaml
@@ -7,3 +7,6 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/part-of: monitoring
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: network
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: storage
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "restricted"
+    pod-security.kubernetes.io/warn: "restricted"


### PR DESCRIPTION
## Changes

Adds Pod Security Standards labels to all 9 namespace manifests.

| Namespace | Enforce | Audit/Warn |
|-----------|---------|------------|
| kube-system | privileged | restricted |
| storage | privileged | restricted |
| monitoring, network, default, database, cert-manager, backup, flux-system | baseline | restricted |

**Why privileged for kube-system/storage:**
- kube-system: Cilium (eBPF) and CoreDNS need host-level access
- storage: Ceph CSI driver pods need privileged for device mounting

**Why baseline for everything else:**
- Blocks dangerous capabilities (privileged containers, hostPID, hostNetwork)
- Allows legitimate workloads (non-root, standard securityContext)
- audit/warn=restricted gives visibility into what would break under stricter enforcement

Part of Optimus security hardening.