### PR TITLE
fix: increase Huntarr memory limit to 1Gi

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
             resources:
               requests:
                 cpu: 25m
-                memory: 256Mi
+                memory: 384Mi
               limits:
-                memory: 768Mi
+                memory: 1Gi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Problem
Huntarr v9.2.3 OOMKilled again at 768Mi limit (raised from 512Mi in PR #191). Memory reaches 555Mi within 13 minutes of startup and continues climbing. Pod restarted once with exit code 137.

## Changes
- Memory request: 256Mi → 384Mi
- Memory limit: 768Mi → 1Gi

## Context
This is the second time we've had to raise Huntarr's memory limit. The baseline memory for v9.2.3 appears to be 500-600Mi with gradual growth over time. 1Gi should provide sufficient headroom.

Closes: N/A (follow-up to #191)