### PR TITLE
fix: backup namespace must be privileged (velero node-agent uses hostPath)

### DIFF
--- a/kubernetes/apps/backup/namespace.yaml
+++ b/kubernetes/apps/backup/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   name: backup
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    pod-security.kubernetes.io/enforce: "baseline"
+    pod-security.kubernetes.io/enforce: "privileged"
     pod-security.kubernetes.io/audit: "restricted"
     pod-security.kubernetes.io/warn: "restricted"


### PR DESCRIPTION
## Problem

Velero's `node-agent` DaemonSet requires `hostPath` volumes (`host-pods`, `host-plugins`) for pod volume backups and CSI snapshots. The backup namespace was configured with PodSecurity `enforce: baseline`, which blocks hostPath volumes.

This caused all node-agent pods to fail creation with:
```
Error creating: pods "node-agent-*" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes
```

## Fix

Changed backup namespace PodSecurity enforcement from `baseline` to `privileged`, matching the pattern used by `monitoring` (node-exporter uses hostPID/hostNetwork) and `storage` (ceph-csi uses hostPath) namespaces.

Audit and warn levels remain at `restricted` for visibility.

## Impact

- Velero node-agent DaemonSet will be able to create pods on all 7 nodes
- Enables volume snapshot backups (CSI snapshots for Ceph RBD PVCs)
- No security regression: only velero workloads run in this namespace