### PR TITLE
fix: increase Huntarr memory to 1.5Gi (OOMKilled 3x at 1Gi)

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
             resources:
               requests:
                 cpu: 25m
-                memory: 384Mi
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 1536Mi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Problem
Huntarr v9.2.3 is OOMKilled repeatedly at 1Gi memory limit. Pod has restarted 3 times today with `Exit Code: 137 (OOMKilled)`. Current memory usage reaches 529Mi within 8 minutes of a restart and grows steadily until hitting the 1Gi limit.

## History
- PR #191: 768Mi (OOM)
- PR #194: 1Gi (OOM — this is where we are)
- **This PR: 1.5Gi**

## Changes
- Memory request: 384Mi → 512Mi (better scheduling signal)
- Memory limit: 1Gi → 1536Mi (1.5Gi)

## Verification
Live patch applied immediately to stop the OOM cycle. This PR makes the change permanent in Git.