### PR TITLE
fix(portfolio): indent ASCII diagram to fix YAML block scalar parsing

### DIFF
--- a/kubernetes/apps/default/portfolio/app/configmap-site.yaml
+++ b/kubernetes/apps/default/portfolio/app/configmap-site.yaml
@@ -378,30 +378,30 @@ data:
             <!-- Architecture Diagram -->
             <div class="arch-diagram">
               <h3>Architecture Overview</h3>
-              <pre class="diagram"><code>Internet
-  |
-  +-- Cloudflare (ragas.sh)
-  |     +-- Proxied to LXC services
-  |
-  +-- OPNsense Firewall (10GbE)
-        +-- Suricata IDS/IPS (190k rules)
-        +-- Tailscale VPN
-        |
-        +-- Proxmox Cluster (pve1-pve4)
-        |     +-- Talos K8s (7 nodes)
-        |     |     +-- Flux GitOps
-        |     |     +-- Cilium CNI
-        |     |     +-- Envoy Gateway
-        |     |     +-- Ceph Storage
-        |     |     +-- 20+ Apps
-        |     |
-        |     +-- LXC Containers
-        |           +-- DNS (bind9 + AdGuard)
-        |           +-- Media (Jellyfin, Plex)
-        |           +-- Optimus (AI Agent)
-        |           +-- Monitoring, Backups
-        |
-        +-- Synology NAS (NFS)</code></pre>
+              <pre class="diagram"><code>    Internet
+      |
+      +-- Cloudflare (ragas.sh)
+      |     +-- Proxied to LXC services
+      |
+      +-- OPNsense Firewall (10GbE)
+            +-- Suricata IDS/IPS (190k rules)
+            +-- Tailscale VPN
+            |
+            +-- Proxmox Cluster (pve1-pve4)
+            |     +-- Talos K8s (7 nodes)
+            |     |     +-- Flux GitOps
+            |     |     +-- Cilium CNI
+            |     |     +-- Envoy Gateway
+            |     |     +-- Ceph Storage
+            |     |     +-- 20+ Apps
+            |     |
+            |     +-- LXC Containers
+            |           +-- DNS (bind9 + AdGuard)
+            |           +-- Media (Jellyfin, Plex)
+            |           +-- Optimus (AI Agent)
+            |           +-- Monitoring, Backups
+            |
+            +-- Synology NAS (NFS)</code></pre>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Problem

The portfolio kustomization has been failing with:

```
kustomize build failed: accumulating resources from 'configmap-site.yaml': MalformedYAMLError: yaml: line 383: could not find expected ':'
```

## Root Cause

The architecture ASCII diagram inside the HTML `<pre><code>` block had lines starting with only 2-3 spaces of indent (e.g., `  |  ` and `  +-- Cloudflare`). Since the YAML block scalar (`|`) for `index.html` establishes a 4-space indent level from the first content line, lines with fewer than 4 spaces of leading whitespace break out of the scalar and get parsed as YAML mappings — causing the parser to choke on `+-- Cloudflare (ragas.sh)` which looks like a malformed YAML key.

## Fix

Added 4 extra spaces to all ASCII diagram lines so they have 6+ spaces of indent, keeping them safely within the YAML block scalar boundary. The relative indentation is preserved, so the diagram renders identically in the browser.