### PR TITLE
fix(huntarr): raise memory limit to 2Gi (5th OOM cycle)

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
                 cpu: 25m
                 memory: 512Mi
               limits:
-                memory: 1536Mi
+                memory: 2Gi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Problem
Huntarr v9.2.4 is OOM-killing repeatedly — 6 restarts in 9h. Current memory usage is 1463Mi out of 1536Mi limit (95%).

The endpoint health check caught `huntarr.ragas.cc` returning HTTP 000000 during an OOM restart cycle.

## Fix
Raise memory limit from 1536Mi to 2Gi.

## History
This is the 5th memory limit increase for Huntarr:
- 512Mi → 768Mi → 1Gi → 1.5Gi (PR #196) → **2Gi** (this PR)

Huntarr v9.2.x has a known memory growth pattern. The baseline keeps climbing with each release.