### PR TITLE
fix: migrate huntarr PVC from ceph-filesystem to ceph-block

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -85,6 +85,6 @@ spec:
       config:
         enabled: true
         type: persistentVolumeClaim
-        existingClaim: huntarr-config
+        existingClaim: huntarr-config-v2
         globalMounts:
           - path: /config

--- a/kubernetes/apps/default/huntarr/app/pvc.yaml
+++ b/kubernetes/apps/default/huntarr/app/pvc.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: huntarr-config
+  name: huntarr-config-v2
   namespace: default
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
-  storageClassName: ceph-filesystem
+  storageClassName: ceph-block


### PR DESCRIPTION
## Problem

Huntarr's SQLite database has been corrupting repeatedly on CephFS — **3 corruptions in a single day** (Feb 20). CephFS metadata operations are incompatible with SQLite's locking and WAL journaling, causing `database disk image is malformed` errors every 1-2 hours.

## Solution

Migrate Huntarr's PVC from `ceph-filesystem` (CephFS) to `ceph-block` (Ceph RBD):
- RBD provides proper block-level semantics that SQLite requires
- Access mode changed from `ReadWriteMany` to `ReadWriteOnce` (Huntarr is single-replica)
- PVC renamed to `huntarr-config-v2` to avoid conflicts with existing PVC

## Migration Status

Data has already been migrated in the cluster:
1. Created new PVC `huntarr-config-v2` (ceph-block, RWO, 2Gi)
2. Ran rsync job to copy all data from old CephFS PVC to new RBD PVC
3. Restored known-good DB from Feb 12 backup
4. Patched deployment to use new PVC
5. Huntarr confirmed healthy (HTTP 302)

Old PVC `huntarr-config` still exists (prune: disabled) and can be cleaned up later.

## Changes

- `pvc.yaml`: renamed to `huntarr-config-v2`, changed to `ceph-block` + `ReadWriteOnce`
- `helmrelease.yaml`: updated `existingClaim` to `huntarr-config-v2`