### PR TITLE
fix: add liveness/readiness probes to Huntarr

### DIFF
--- a/kubernetes/apps/default/huntarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/huntarr/app/helmrelease.yaml
@@ -26,9 +26,25 @@ spec:
               TZ: America/Los_Angeles
             probes:
               liveness:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9705
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  failureThreshold: 3
+                  timeoutSeconds: 3
               readiness:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9705
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 3
+                  timeoutSeconds: 3
               startup:
                 enabled: true
                 custom: true


### PR DESCRIPTION
## Problem

Huntarr's Waitress web server dies silently when its SQLite DB corrupts (5th occurrence today — now confirmed as app-level bug, not storage). The pod stays in `Running` state because the backup scheduler thread keeps the process alive, but port 9705 stops listening. This causes prolonged 503s until manual pod restart.

## Fix

Enable TCP socket liveness and readiness probes on port 9705:
- **Liveness:** 15s interval, 3 failures → pod restart (~45s to auto-recover)
- **Readiness:** 10s interval, 3 failures → stops routing traffic to zombie pod
- **Startup:** unchanged (5s interval, 60 failures = 5min startup window)

This ensures K8s automatically restarts the pod when Waitress crashes, instead of requiring manual intervention.

## Context

Huntarr has had 5 SQLite corruption events today. The CephFS→Ceph RBD migration (PR #251) didn't fix it — the corruption is app-level (Huntarr v9.3.7 bug). With probes, the pod will self-heal within ~45s instead of staying in a zombie state indefinitely.