### PR TITLE
feat: add Flux manifests for personal-site deployment

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - ./agregarr/ks.yaml
   - ./optimus/ks.yaml
   - ./portfolio/ks.yaml
+  - ./personal-site/ks.yaml

--- a/kubernetes/apps/default/personal-site/app/deployment.yaml
+++ b/kubernetes/apps/default/personal-site/app/deployment.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: personal-site
+  labels:
+    app.kubernetes.io/name: personal-site
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: personal-site
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: personal-site
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: personal-site
+  labels:
+    app.kubernetes.io/name: personal-site
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: personal-site
+  ports:
+    - port: 80
+      targetPort: 80

--- a/kubernetes/apps/default/personal-site/app/httproute.yaml
+++ b/kubernetes/apps/default/personal-site/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: personal-site
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  hostnames:
+    - "www.ragas.sh"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: personal-site
+          port: 80

--- a/kubernetes/apps/default/personal-site/app/kustomization.yaml
+++ b/kubernetes/apps/default/personal-site/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - httproute.yaml

--- a/kubernetes/apps/default/personal-site/ks.yaml
+++ b/kubernetes/apps/default/personal-site/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: personal-site
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: personal-site
+  path: ./kubernetes/apps/default/personal-site/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m


### PR DESCRIPTION
Deploy personal-site (nginx) to the cluster with:
- Deployment: nginx:1.27-alpine, 1 replica, resource requests/limits
- Service: ClusterIP on port 80
- HTTPRoute: www.ragas.sh via envoy-external gateway
- Flux Kustomization: 30m interval, prune enabled

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>