### PR TITLE
fix: route www.ragas.sh and ragas.sh through CF tunnel to portfolio

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -90,6 +90,10 @@ spec:
             ingress:
               - hostname: "request.ragas.sh"
                 service: http://overseerr.default.svc.cluster.local:5055
+              - hostname: "www.ragas.sh"
+                service: http://portfolio.default.svc.cluster.local:80
+              - hostname: "ragas.sh"
+                service: http://portfolio.default.svc.cluster.local:80
               - hostname: "*.ragas.sh"
                 service: http://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:80
               - service: http_status:404


### PR DESCRIPTION
## Problem
`www.ragas.sh` returns HTTP 403 (detected by website-health skill). Two issues:

1. **Cloudflare DNS misconfigured**: `www.ragas.sh` and `ragas.sh` resolve to `172.16.1.31` (non-existent internal IP) instead of CNAME to CF tunnel
2. **CF tunnel routing gap**: The wildcard `*.ragas.sh` route sends traffic to `envoy-external:80`, which only has an HTTPS redirect rule — creating a redirect loop instead of serving the portfolio

## Fix
Add explicit hostname entries for `www.ragas.sh` and `ragas.sh` in the Cloudflare tunnel ingress config, routing directly to the portfolio service (`http://portfolio.default.svc.cluster.local:80`). This follows the same pattern as `request.ragas.sh` → overseerr.

## Still Needed (Manual)
Cloudflare DNS must be updated to CNAME `www` and `@` (or `ragas.sh`) to `30286f86-9062-47bd-92f2-80d94cdb17b0.cfargotunnel.com` with proxy enabled (orange cloud).

## Verification
- Portfolio pod is healthy: `1/1 Running`, serving HTTP 200 with 18KB responses
- CF tunnel pods healthy: `2/2 Running`, 4 connections registered
- Pattern matches existing `request.ragas.sh` → overseerr direct route